### PR TITLE
change schema draft to draft2020-12

### DIFF
--- a/97-add-schema/add-schema-to-notebook-format.md
+++ b/97-add-schema/add-schema-to-notebook-format.md
@@ -40,7 +40,7 @@ The following changes are made to the existing v4.5 schema:
  {
 -  "$schema": "http://json-schema.org/draft-04/schema#",
 -  "description": "Jupyter Notebook v4.5 JSON schema.",
-+  "$schema": "http://json-schema.org/draft-07/schema#",
++  "$schema": "https://json-schema.org/draft/2020-12/schema",
 +  "$id": "https://jupyter.org/schema/notebook/4.6/notebook-4.6.schema.json",
 +  "description": "Jupyter Notebook v4.6 JSON schema.",
    "type": "object",
@@ -80,7 +80,7 @@ The following changes are made to the existing v4.5 schema:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://jupyter.org/schema/notebook/4.6/notebook-4.6.schema.json",
   "description": "Jupyter Notebook v4.6 JSON schema.",
   "type": "object",


### PR DESCRIPTION
this pull request points the schema to https://json-schema.org/draft/2020-12/schema.
we need to bump the schema to at least Draft2019 to gain the deprecation semantics.
yesterday in the schema meeting we decided that we should be using to the most current draft to get the most out of json schema.